### PR TITLE
問題別ランキング表示

### DIFF
--- a/app/assets/javascripts/typing.js
+++ b/app/assets/javascripts/typing.js
@@ -88,6 +88,7 @@ onPageLoad('questions#play', function() {
     $('i').remove();
     gEle1.innerHTML = str1;
     gEle2.innerHTML = japanese_translation;
+
     // 問題が変わる度に表示が消されるのは変なので、最初に一度表示したら終わるまで表示したままにしておく
     if ( gWrong_cnt===0 && gCorrect_cnt===0 ) {
       gEle4.innerHTML = gEle3.innerHTML = "";
@@ -160,7 +161,7 @@ onPageLoad('questions#play', function() {
         processData: false,
         contentType: 'application/json'
       })
-      .done(function(){
+      .done(function(aiueo){
         console.log("タイピング結果の送信成功");
       })
       .fail(function(){

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,3 +7,4 @@
 @import './modules/devise';
 @import "./question/show";
 @import "./question/play";
+@import "./ranking/show";

--- a/app/assets/stylesheets/ranking/show.scss
+++ b/app/assets/stylesheets/ranking/show.scss
@@ -1,0 +1,32 @@
+.ranking {
+  max-width: 760px;
+  white-space: nowrap;
+  
+  table.ranking {
+    // background-color: white;
+    // table-layout:fixed;
+    .thtd { 
+      background-color: lightyellow;
+    }
+    .trtd {
+      background-color: white;
+    }
+    td {
+      // text-align: center;
+      // padding-left: 6px;
+      border: 2px solid $accent;
+      // background-color: lightyellow;
+    }
+    td.num {
+      text-align: right;
+    }
+    td:empty {
+      visibility:hidden;
+      border-top: 0px;
+    }
+  }
+  &__link {
+    margin-top: 20px;
+    text-align: right;
+  }
+}

--- a/app/controllers/rankings_controller.rb
+++ b/app/controllers/rankings_controller.rb
@@ -1,9 +1,10 @@
 class RankingsController < ApplicationController
   def index
-      @aggregates = Qfile.joins(:results).select("qfiles.id, qfiles.title, qfiles.results_count, COUNT(distinct results.user_id) AS count_distinct_results_user_id").group("results.qfile_id, qfiles.category, results_count").order("qfiles.id ASC")
+    @aggregates = Qfile.joins(:results).select("qfiles.id, qfiles.title, qfiles.results_count, COUNT(distinct results.user_id) AS count_distinct_results_user_id").group("results.qfile_id, qfiles.category, results_count").order("qfiles.id ASC")
   end
 
   def show
+    @results = Result.order("results.speed DESC, results.created_at ASC").where(qfile_id: params[:id])
   end
 
 end

--- a/app/views/questions/index.html.haml
+++ b/app/views/questions/index.html.haml
@@ -31,27 +31,27 @@
             %td
               = link_to 'certify	- drill 200語', "/questions/2", method: :get
             %td
-              = link_to @aggregates.to_a[1].count_distinct_results_user_id.to_s + 'ユーザーが、' + @aggregates.to_a[1].results_count.to_s + '回実行', "/rankings/#{@aggregates.to_a[0].id.to_s}", method: :get
+              = link_to @aggregates.to_a[1].count_distinct_results_user_id.to_s + 'ユーザーが、' + @aggregates.to_a[1].results_count.to_s + '回実行', "/rankings/#{@aggregates.to_a[1].id.to_s}", method: :get
           %tr
             %td
               = link_to 'drought	- indoor 200語', "/questions/3", method: :get
             %td
-              = link_to @aggregates.to_a[2].count_distinct_results_user_id.to_s + 'ユーザーが、' + @aggregates.to_a[2].results_count.to_s + '回実行', "/rankings/#{@aggregates.to_a[0].id.to_s}", method: :get
+              = link_to @aggregates.to_a[2].count_distinct_results_user_id.to_s + 'ユーザーが、' + @aggregates.to_a[2].results_count.to_s + '回実行', "/rankings/#{@aggregates.to_a[2].id.to_s}", method: :get
           %tr
             %td
               = link_to 'induction - painter 200語', "/questions/4", method: :get
             %td
-              = link_to @aggregates.to_a[3].count_distinct_results_user_id.to_s + 'ユーザーが、' + @aggregates.to_a[3].results_count.to_s + '回実行', "/rankings/#{@aggregates.to_a[0].id.to_s}", method: :get
+              = link_to @aggregates.to_a[3].count_distinct_results_user_id.to_s + 'ユーザーが、' + @aggregates.to_a[3].results_count.to_s + '回実行', "/rankings/#{@aggregates.to_a[3].id.to_s}", method: :get
           %tr
             %td
               = link_to 'pamphlet - satellite 200語', "/questions/5", method: :get
             %td
-              = link_to @aggregates.to_a[4].count_distinct_results_user_id.to_s + 'ユーザーが、' + @aggregates.to_a[4].results_count.to_s + '回実行', "/rankings/#{@aggregates.to_a[0].id.to_s}", method: :get
+              = link_to @aggregates.to_a[4].count_distinct_results_user_id.to_s + 'ユーザーが、' + @aggregates.to_a[4].results_count.to_s + '回実行', "/rankings/#{@aggregates.to_a[4].id.to_s}", method: :get
           %tr
             %td
               = link_to 'satisfactory - zoo 259語', "/questions/6", method: :get
             %td
-              = link_to @aggregates.to_a[5].count_distinct_results_user_id.to_s + 'ユーザーが、' + @aggregates.to_a[5].results_count.to_s + '回実行', "/rankings/#{@aggregates.to_a[0].id.to_s}", method: :get
+              = link_to @aggregates.to_a[5].count_distinct_results_user_id.to_s + 'ユーザーが、' + @aggregates.to_a[5].results_count.to_s + '回実行', "/rankings/#{@aggregates.to_a[5].id.to_s}", method: :get
     .box
       .category
         %h2
@@ -67,19 +67,19 @@
             %td
               = link_to '英語例文 200件 1', "/questions/7", method: :get
             %td
-              = link_to @aggregates.to_a[6].count_distinct_results_user_id.to_s + 'ユーザーが、' + @aggregates.to_a[6].results_count.to_s + '回実行', "/rankings/#{@aggregates.to_a[0].id.to_s}", method: :get
+              = link_to @aggregates.to_a[6].count_distinct_results_user_id.to_s + 'ユーザーが、' + @aggregates.to_a[6].results_count.to_s + '回実行', "/rankings/#{@aggregates.to_a[6].id.to_s}", method: :get
           %tr
             %td
               = link_to '英語例文 200件 2', "/questions/8", method: :get
             %td
-              = link_to @aggregates.to_a[7].count_distinct_results_user_id.to_s + 'ユーザーが、' + @aggregates.to_a[7].results_count.to_s + '回実行', "/rankings/#{@aggregates.to_a[0].id.to_s}", method: :get
+              = link_to @aggregates.to_a[7].count_distinct_results_user_id.to_s + 'ユーザーが、' + @aggregates.to_a[7].results_count.to_s + '回実行', "/rankings/#{@aggregates.to_a[7].id.to_s}", method: :get
           %tr
             %td
               = link_to '英語例文 200件 3', "/questions/9", method: :get
             %td
-              = link_to @aggregates.to_a[8].count_distinct_results_user_id.to_s + 'ユーザーが、' + @aggregates.to_a[8].results_count.to_s + '回実行', "/rankings/#{@aggregates.to_a[0].id.to_s}", method: :get
+              = link_to @aggregates.to_a[8].count_distinct_results_user_id.to_s + 'ユーザーが、' + @aggregates.to_a[8].results_count.to_s + '回実行', "/rankings/#{@aggregates.to_a[8].id.to_s}", method: :get
           %tr
             %td
               = link_to '英語例文 200件 4', "/questions/10", method: :get
             %td
-              = link_to @aggregates.to_a[9].count_distinct_results_user_id.to_s + 'ユーザーが、' + @aggregates.to_a[9].results_count.to_s + '回実行', "/rankings/#{@aggregates.to_a[0].id.to_s}", method: :get
+              = link_to @aggregates.to_a[9].count_distinct_results_user_id.to_s + 'ユーザーが、' + @aggregates.to_a[9].results_count.to_s + '回実行', "/rankings/#{@aggregates.to_a[9].id.to_s}", method: :get

--- a/app/views/questions/play.html.haml
+++ b/app/views/questions/play.html.haml
@@ -21,3 +21,6 @@
       %p{ id: "wrong_cnt" }
   .link-to-top
     = link_to 'トップへ戻る', "/"
+    %br
+    %br
+    = link_to 'ランキングを見る', ranking_path

--- a/app/views/rankings/show.html.haml
+++ b/app/views/rankings/show.html.haml
@@ -1,0 +1,38 @@
+.content.ranking
+  %table.ranking
+    - @results.each.with_index(1) do |result, idx|
+      - if idx===1 then
+        %th
+          %td.thtd.num
+            順位
+          %td.thtd
+            名前
+          %td.thtd.num
+            正解(key)
+          %td.thtd.num
+            誤(key)
+          %td.thtd.num
+            時間(s)
+          %td.thtd.num
+            速度(key/s)
+          %td.thtd
+            実行日
+      %tr
+        -# haml記法の影響で、ヘッダと比較して左方向に1セルずれてしまうのでダミーセルを入れて調整する
+        %td.trtd
+        %td.trtd.num
+          = idx
+        %td.trtd
+          = result.user.nickname
+        %td.trtd.num
+          = result.correct_cnt
+        %td.trtd.num
+          = result.wrong_cnt
+        %td.trtd.num
+          = result.elapsed_time
+        %td.trtd.num
+          = result.speed
+        %td.trtd
+          = result.created_at.strftime('%Y/%m/%d %H:%M')
+  .ranking__link
+    = link_to '爪痕を残す', play_question_path, method: :get

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,7 @@ module GameTyping
     config.load_defaults 5.2
     config.i18n.default_locale = :ja
     config.active_record.default_timezone = :local
+    config.time_zone = 'Tokyo'
     config.generators do |g|
       g.stylesheets false
       g.javascripts false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,4 +61,13 @@ Rails.application.configure do
 
   # mailer setting
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.smtp_settings = {
+    :address => "smtp.gmail.com",
+    :port => 587,
+    :user_name => ENV['GMAIL_ADDRESS'],
+    :password => ENV['GMAIL_PASS'],
+    :authentication => :plain,
+    :enable_starttls_auto => true
+  }
+
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,4 +91,12 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+  config.action_mailer.smtp_settings = {
+    :address => "smtp.gmail.com",
+    :port => 587,
+    :user_name => ENV['GMAIL_ADDRESS'],
+    :password => ENV['GMAIL_PASS'],
+    :authentication => :plain,
+    :enable_starttls_auto => true
+  }
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'd0o0r0a0e0m0o0n@gmail.com'
+  config.mailer_sender = ENV['GMAIL_ADDRESS']
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
・問題別のランキング表示のマークアップ
・表示させるデータの取得(コントローラ）
・トップページのリンク修正
・取得した時間の表示がUTCになってしまうので、config.time_zone = 'Tokyo'追加
・パスワード再設定の送信元メール設定を追加
・パスワード再設定の送信元メールアドレスを環境変数化